### PR TITLE
Add announcement ticker

### DIFF
--- a/components/announcement-ticker.tsx
+++ b/components/announcement-ticker.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+export default function AnnouncementTicker() {
+  const messages = [
+    "Applications for the 2025 cohort are now open!",
+    "Join our AI & ML workshop on February 20th.",
+    "Investor networking night on February 25th."
+  ]
+
+  return (
+    <div className="w-full border-b bg-primary text-primary-foreground text-sm overflow-hidden">
+      <div className="animate-marquee whitespace-nowrap py-2">
+        {messages.map((msg, idx) => (
+          <span key={idx} className="mx-8">{msg}</span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -14,11 +14,13 @@ import {
 } from "@/components/ui/navigation-menu"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { Search, User, Menu, GraduationCap } from "lucide-react"
+import AnnouncementTicker from "./announcement-ticker"
 
 export default function Header() {
   const [isSearchOpen, setIsSearchOpen] = useState(false)
 
   return (
+    <>
     <header className="sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60">
       <div className="container flex h-16 items-center justify-between px-4">
         {/* Logo */}
@@ -237,5 +239,7 @@ export default function Header() {
         </div>
       )}
     </header>
+    <AnnouncementTicker />
+    </>
   )
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -68,6 +68,7 @@ const config: Config = {
   			sm: 'calc(var(--radius) - 4px)'
   		},
   		keyframes: {
+                        marquee: {"0%": { transform: "translateX(100%)" }, "100%": { transform: "translateX(-100%)" } },
   			'accordion-down': {
   				from: {
   					height: '0'
@@ -86,6 +87,7 @@ const config: Config = {
   			}
   		},
   		animation: {
+                        marquee: "marquee 25s linear infinite",
   			'accordion-down': 'accordion-down 0.2s ease-out',
   			'accordion-up': 'accordion-up 0.2s ease-out'
   		}


### PR DESCRIPTION
## Summary
- add `AnnouncementTicker` component for displaying announcements
- include ticker in `Header` below navigation
- configure marquee animation in Tailwind

## Testing
- `npm install` *(fails: ERESOLVE could not resolve)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a35332c1c832fb3aa044a52f90418